### PR TITLE
Fix archiver failing from docx

### DIFF
--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -310,7 +310,7 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
                 return
 
             mimetype = None
-            headers = None
+            headers = {}
             content_type, content_encoding = mimetypes.guess_type(url)
             if content_type:
                 mimetype = _clean_content_type(content_type)


### PR DESCRIPTION
Setting default headers to empty dict to fix NoneType exception when mimetypes.guess_type returns None